### PR TITLE
Send /n terminator.

### DIFF
--- a/gemini_app.c
+++ b/gemini_app.c
@@ -31,11 +31,11 @@ bool gemini_app_send_api_key(GeminiApp* app) {
             memset(key, 0, COUNT_OF(key));
             size_t bytes_read = storage_file_read(file, key, COUNT_OF(key));
             if (bytes_read > 0) {
-                size_t bytes_send = bytes_read + 1; // Add one for the null character.
+                size_t bytes_send = bytes_read;
                 for (size_t i = 0; i < bytes_read; i++) {
                     if ((key[i] == '\r') || (key[i] == '\n') || (key[i] == ' ')) {
                         key[i] = '\0';
-                        bytes_send = i;
+                        bytes_send = 0;
                         break;
                     }
                 }

--- a/helpers/uart_helper.c
+++ b/helpers/uart_helper.c
@@ -233,11 +233,18 @@ bool uart_helper_read(UartHelper* helper, FuriString* text) {
 
 void uart_helper_send(UartHelper* helper, const char* data, size_t length) {
     if (length == 0) {
-        length = strlen(data) + 1;
+        length = strlen(data); // Exclude the null character.
+        char* buf = malloc(length + 2); // Null and delimiter.
+        memcpy(buf, data, length);
+        buf[length++] = '\n'; // Add a newline character.
+        buf[length] = 0; // Null terminate the string.
+        data = buf;        
+        furi_hal_serial_tx(helper->serial_handle, (uint8_t*)data, length);
+        free(buf);
+    } else {
+        // Transmit data via UART TX.
+        furi_hal_serial_tx(helper->serial_handle, (uint8_t*)data, length);
     }
-
-    // Transmit data via UART TX.
-    furi_hal_serial_tx(helper->serial_handle, (uint8_t*)data, length);
 }
 
 void uart_helper_send_string(UartHelper* helper, FuriString* string) {

--- a/scenes/gemini_scene_set_name.c
+++ b/scenes/gemini_scene_set_name.c
@@ -27,7 +27,7 @@ bool gemini_scene_set_name_on_event(void* context, SceneManagerEvent event) {
     if (event.type == SceneManagerEventTypeCustom) {
         switch(event.event) {
             case GeminiSceneSetNameEventOk:
-                uart_helper_send(app->uart_helper, text_buffer, TEXT_BUFFER_SIZE);
+                uart_helper_send(app->uart_helper, text_buffer, 0);
                 // We want BACK to go back to the main menu, not our current scene.
                 gemini_scene_receive_serial_set_next(app, GeminiSceneSendKnownAps);
                 scene_manager_search_and_switch_to_another_scene(app->scene_manager, GeminiSceneReceiveSerial);


### PR DESCRIPTION
Terminate text with \n character, instead of sending null terminator.  This fix now makes it so the API key & name work.

note: "Start Chatting" isn't implemented yet, however after connecting to a known wi-fi, if you choose "Set Name" again and type in a question, Gemini will respond!  You should then reboot your Flipper with BACK+LEFT (or else you will end up sending Gemini your wi-fi credentials).